### PR TITLE
Add config file to use GPUs

### DIFF
--- a/cloudml-gpu.yaml
+++ b/cloudml-gpu.yaml
@@ -1,0 +1,4 @@
+trainingInput:
+  scaleTier: CUSTOM
+  # standard_gpu provides 1 GPU. Change to complex_model_m_gpu for 4 GPUs
+  masterType: standard_gpu


### PR DESCRIPTION
This config file can be used by the gcloud command to tell CloudML to use GPU resources.