### PR TITLE
Implement batch reading for the video-level reader

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -109,7 +109,8 @@ def get_input_evaluation_tensors(reader,
         eval_data,
         batch_size=batch_size,
         capacity=3 * batch_size,
-        allow_smaller_final_batch=True)
+        allow_smaller_final_batch=True,
+        enqueue_many=True)
 
 
 def build_graph(reader,

--- a/inference.py
+++ b/inference.py
@@ -106,7 +106,8 @@ def get_input_data_tensors(reader, data_pattern, batch_size, num_readers=1):
     video_id_batch, video_batch, unused_labels, num_frames_batch = (
         tf.train.batch_join(examples_and_labels,
                             batch_size=batch_size,
-                            allow_smaller_final_batch = True))
+                            allow_smaller_final_batch = True,
+                            enqueue_many=True))
     return video_id_batch, video_batch, num_frames_batch
 
 def inference(reader, train_dir, data_pattern, out_file_location, batch_size, top_k):

--- a/readers.py
+++ b/readers.py
@@ -120,7 +120,7 @@ class YT8MAggregatedFeatureReader(BaseReader):
     labels = tf.sparse_to_indicator(features["labels"], self.num_classes)
     labels.set_shape([None, self.num_classes])
     concatenated_features = tf.concat([
-        features[feature_name] for feature_name in self.feature_names], 0)
+        features[feature_name] for feature_name in self.feature_names], 1)
 
     return features["video_id"], concatenated_features, labels, tf.ones([tf.shape(serialized_examples)[0]])
 

--- a/readers.py
+++ b/readers.py
@@ -123,7 +123,6 @@ class YT8MAggregatedFeatureReader(BaseReader):
     concatenated_features = tf.concat([
         features[feature_name] for feature_name in self.feature_names], 0)
 
-    #import pdb; pdb.set_trace()
     return features["video_id"], concatenated_features, labels, tf.ones([tf.shape(serialized_examples)[0]])
 
 class YT8MFrameFeatureReader(BaseReader):
@@ -250,5 +249,13 @@ class YT8MFrameFeatureReader(BaseReader):
 
     # concatenate different features
     video_matrix = tf.concat(feature_matrices, 1)
-    return contexts["video_id"], video_matrix, labels, num_frames
+
+    # convert to batch format.
+    # TODO: Do proper batch reads to remove the IO bottleneck.
+    batch_video_ids = tf.expand_dims(contexts["video_id"], 0)
+    batch_video_matrix = tf.expand_dims(video_matrix, 0)
+    batch_labels = tf.expand_dims(labels, 0)
+    batch_frames = tf.expand_dims(num_frames, 0)
+
+    return batch_video_ids, batch_video_matrix, batch_labels, batch_frames
 

--- a/train.py
+++ b/train.py
@@ -155,7 +155,8 @@ def get_input_data_tensors(reader,
         batch_size=batch_size,
         capacity=FLAGS.batch_size * 5,
         min_after_dequeue=FLAGS.batch_size,
-        allow_smaller_final_batch=True)
+        allow_smaller_final_batch=True,
+        enqueue_many=True)
 
 
 def find_class_by_name(name, modules):


### PR DESCRIPTION
The frame level reader is more complicated, so I'm pushing this change first and will follow up with a batched frame-level reader later.