### PR TITLE
Modify saver to save less often and retain checkpoints from throughout the training process

### DIFF
--- a/train.py
+++ b/train.py
@@ -295,7 +295,7 @@ def train_loop(train_dir=None,
   sess = sv.prepare_or_wait_for_session(
       master,
       start_standard_services=start_supervisor_services,
-      config=tf.ConfigProto(log_device_placement=False))
+      config=tf.ConfigProto(log_device_placement=True,allow_soft_placement=True))
 
   logging.info("prepared session")
   sv.start_queue_runners(sess)
@@ -395,7 +395,7 @@ def main(unused_argv):
                 num_readers=FLAGS.num_readers,
                 batch_size=FLAGS.batch_size)
     logging.info("built graph")
-    saver = tf.train.Saver()
+    saver = tf.train.Saver(keep_checkpoint_every_n_hours=0.5)
 
   train_loop(is_chief=is_chief,
              train_dir=FLAGS.train_dir,

--- a/train.py
+++ b/train.py
@@ -289,8 +289,8 @@ def train_loop(train_dir=None,
   sv = tf.train.Supervisor(logdir=train_dir,
                            is_chief=is_chief,
                            global_step=global_step,
-                           save_model_secs=60,
-                           save_summaries_secs=60,
+                           save_model_secs=15 * 60,
+                           save_summaries_secs=120,
                            saver=saver)
   sess = sv.prepare_or_wait_for_session(
       master,

--- a/train.py
+++ b/train.py
@@ -396,7 +396,7 @@ def main(unused_argv):
                 num_readers=FLAGS.num_readers,
                 batch_size=FLAGS.batch_size)
     logging.info("built graph")
-    saver = tf.train.Saver(keep_checkpoint_every_n_hours=0.5)
+    saver = tf.train.Saver(max_to_keep=0, keep_checkpoint_every_n_hours=0.25)
 
   train_loop(is_chief=is_chief,
              train_dir=FLAGS.train_dir,


### PR DESCRIPTION
This gives about a 10% speedup from the reduced save frequency, and facilitates selection of an optimal checkpoint.