### PR TITLE
Bug fix: return value is only defined is master.

### DIFF
--- a/train.py
+++ b/train.py
@@ -398,7 +398,6 @@ class Trainer(object):
 
     logging.info("%s: Exited training loop.", task_as_string(self.task))
     sv.Stop()
-    return hit_at_one, perr
 
   def start_server_if_distributed(self):
     """Starts a server if the execution is distributed."""


### PR DESCRIPTION
Fixing a bug with the return value of Trainer.run in the case of a worker ("hit_at_one" is not defined in the case of a worker).