### PR TITLE
Fix builtin range import for Python 2.7+.

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -24,7 +24,7 @@ from tensorflow import app
 from tensorflow import flags
 from tensorflow import gfile
 from tensorflow import logging
-from builtins import range
+from __builtin__ import range
 
 import eval_util
 import losses


### PR DESCRIPTION
inference.py throws ImportError in Python 2.7 due to "from builtins import range".