### PR TITLE
modify lstm ouput for aggregated model

### DIFF
--- a/frame_level_models.py
+++ b/frame_level_models.py
@@ -231,6 +231,6 @@ class LstmModel(models.BaseModel):
     aggregated_model = getattr(video_level_models,
                                FLAGS.video_level_classifier_model)
     return aggregated_model().create_model(
-        model_input=state,
+        model_input=state[-1],
         vocab_size=vocab_size,
         **unused_params)

--- a/frame_level_models.py
+++ b/frame_level_models.py
@@ -218,9 +218,9 @@ class LstmModel(models.BaseModel):
     stacked_lstm = tf.contrib.rnn.MultiRNNCell(
             [
                 tf.contrib.rnn.BasicLSTMCell(
-                    lstm_size, forget_bias=1.0, state_is_tuple=False)
+                    lstm_size, forget_bias=1.0)
                 for _ in range(number_of_layers)
-                ], state_is_tuple=False)
+                ])
 
     loss = 0.0
     with tf.variable_scope("RNN"):
@@ -231,6 +231,6 @@ class LstmModel(models.BaseModel):
     aggregated_model = getattr(video_level_models,
                                FLAGS.video_level_classifier_model)
     return aggregated_model().create_model(
-        model_input=state[-1],
+        model_input=state[-1].h,
         vocab_size=vocab_size,
         **unused_params)


### PR DESCRIPTION
Using the h value of the lstm top layer as the input for aggregated model is better, and easier to converge.


- Train log:
INFO:tensorflow:/job:master/task:0: training step 218206| Hit@1: 0.87 PERR: 0.72 GAP: 0.81 Loss: 5.09105
INFO:tensorflow:/job:master/task:0: training step 218207| Hit@1: 0.85 PERR: 0.73 GAP: 0.81 Loss: 5.16746
INFO:tensorflow:/job:master/task:0: training step 218208| Hit@1: 0.79 PERR: 0.68 GAP: 0.80 Loss: 5.13253
INFO:tensorflow:/job:master/task:0: training step 218209| Hit@1: 0.90 PERR: 0.76 GAP: 0.82 Loss: 5.16415
INFO:tensorflow:/job:master/task:0: training step 218210| Hit@1: 0.88 PERR: 0.76 GAP: 0.80 Loss: 5.36496
INFO:tensorflow:/job:master/task:0: training step 218211| Hit@1: 0.83 PERR: 0.72 GAP: 0.82 Loss: 4.48507
INFO:tensorflow:/job:master/task:0: training step 218212| Hit@1: 0.85 PERR: 0.71 GAP: 0.83 Loss: 4.91971

- Eval on frame level validation set,
Avg_Hit@1: 0.838 | Avg_PERR: 0.705 | MAP: 0.367 | GAP: 0.780 | Avg_Loss: 5.795533

- The following are the training status
  The orange curves:  original code using all concatenated state. 
  The blue curves: modified code using top layer h state.
![image](https://cloud.githubusercontent.com/assets/9128530/25037915/68cb28b6-212e-11e7-94ef-bab3b9d10ed0.png)