### PR TITLE
from six.moves import cPickle in feature_extractor_test.py

### DIFF
--- a/feature_extractor/feature_extractor_test.py
+++ b/feature_extractor/feature_extractor_test.py
@@ -19,6 +19,7 @@ import os
 import feature_extractor
 import numpy
 from PIL import Image
+from six.moves import cPickle
 from tensorflow.python.platform import googletest
 
 


### PR DESCRIPTION
__cPickle__ is used on line 45 but it is never imported.
* http://six.readthedocs.io/index.html?highlight=cpickle#module-six.moves

__feature_extractor_test.py__ already uses the __six__ module so it should be acceptable for __feature_extractor_test.py__ to do so as well.