### PR TITLE
Fix Webpage Anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cd ~/yt8m/code
 git clone https://github.com/google/youtube-8m.git
 ```
 
-#### Train video-level model
+#### Training on Video-Level Features
 ```
 python train.py --feature_names='mean_rgb,mean_audio' --feature_sizes='1024,128' --train_data_pattern=${HOME}/yt8m/v2/video/train*.tfrecord --train_dir ~/yt8m/v2/models/video/sample_model --start_new_model
 ```


### PR DESCRIPTION
In README.md, the name of one of the link in Table of Contents is not similar to the content's title, as a result, clicking on it won't auto-scroll down to that specific content. My pull-request have fixed that by changing the content title.

![pul1](https://user-images.githubusercontent.com/34149262/40577878-a49cd218-60c0-11e8-92d5-9706a308137e.png)
![pul2](https://user-images.githubusercontent.com/34149262/40577879-a4b4ffd2-60c0-11e8-860e-9e90b880e68d.png)
