### PR TITLE
use tf rewrite pca operation

### DIFF
--- a/feature_extractor/feature_extractor.py
+++ b/feature_extractor/feature_extractor.py
@@ -19,6 +19,7 @@ import tarfile
 import numpy
 from six.moves import urllib
 import tensorflow as tf
+import time
 
 INCEPTION_TF_GRAPH = 'http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz'
 YT8M_PCA_MAT = 'http://data.yt8m.org/yt8m_pca.tgz'
@@ -64,6 +65,13 @@ class YouTube8MFeatureExtractor(object):
     if not os.path.exists(model_dir):
       os.makedirs(model_dir)
 
+    # Load PCA Matrix.
+    download_path = self._maybe_download(YT8M_PCA_MAT)
+    pca_mean = os.path.join(self._model_dir, 'mean.npy')
+    if not os.path.exists(pca_mean):
+      tarfile.open(download_path, 'r:gz').extractall(model_dir)
+    self._load_pca()
+
     # Load Inception Network
     download_path = self._maybe_download(INCEPTION_TF_GRAPH)
     inception_proto_file = os.path.join(
@@ -72,12 +80,7 @@ class YouTube8MFeatureExtractor(object):
       tarfile.open(download_path, 'r:gz').extractall(model_dir)
     self._load_inception(inception_proto_file)
 
-    # Load PCA Matrix.
-    download_path = self._maybe_download(YT8M_PCA_MAT)
-    pca_mean = os.path.join(self._model_dir, 'mean.npy')
-    if not os.path.exists(pca_mean):
-      tarfile.open(download_path, 'r:gz').extractall(model_dir)
-    self._load_pca()
+
 
   def extract_rgb_frame_features(self, frame_rgb, apply_pca=True):
     """Applies the YouTube8M feature extraction over an RGB frame.
@@ -98,13 +101,8 @@ class YouTube8MFeatureExtractor(object):
     assert len(frame_rgb.shape) == 3
     assert frame_rgb.shape[2] == 3  # 3 channels (R, G, B)
     with self._inception_graph.as_default():
-      frame_features = self.session.run('pool_3/_reshape:0',
+      frame_features = self.session.run('pca_final_feature:0',
                                         feed_dict={'DecodeJpeg:0': frame_rgb})
-      frame_features = frame_features[0]  # Unbatch.
-
-    if apply_pca:
-      frame_features = self.apply_pca(frame_features)
-
     return frame_features
 
   def apply_pca(self, frame_features):
@@ -148,6 +146,14 @@ class YouTube8MFeatureExtractor(object):
     with self._inception_graph.as_default():
       _ = tf.import_graph_def(graph_def, name='')
       self.session = tf.Session()
+      Frame_Features = self.session.graph.get_tensor_by_name('pool_3/_reshape:0')
+      Pca_Mean = tf.constant(value=self.pca_mean, dtype=tf.float32)
+      Pca_Eigenvecs = tf.constant(value=self.pca_eigenvecs, dtype=tf.float32)
+      Pca_Eigenvals = tf.constant(value=self.pca_eigenvals, dtype=tf.float32)
+      Feats = Frame_Features[0] - Pca_Mean
+      Feats = tf.reshape(tf.matmul(tf.reshape(Feats, [1, 2048]), Pca_Eigenvecs), [1024, ])
+      Feats = tf.divide(Feats, tf.sqrt(Pca_Eigenvals + 1e-4), name='pca_final_feature')
+      print Feats.name
 
   def _load_pca(self):
     self.pca_mean = numpy.load(

--- a/feature_extractor/feature_extractor.py
+++ b/feature_extractor/feature_extractor.py
@@ -19,7 +19,6 @@ import tarfile
 import numpy
 from six.moves import urllib
 import tensorflow as tf
-import time
 
 INCEPTION_TF_GRAPH = 'http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz'
 YT8M_PCA_MAT = 'http://data.yt8m.org/yt8m_pca.tgz'
@@ -152,8 +151,7 @@ class YouTube8MFeatureExtractor(object):
       Pca_Eigenvals = tf.constant(value=self.pca_eigenvals, dtype=tf.float32)
       Feats = Frame_Features[0] - Pca_Mean
       Feats = tf.reshape(tf.matmul(tf.reshape(Feats, [1, 2048]), Pca_Eigenvecs), [1024, ])
-      Feats = tf.divide(Feats, tf.sqrt(Pca_Eigenvals + 1e-4), name='pca_final_feature')
-      print Feats.name
+      tf.divide(Feats, tf.sqrt(Pca_Eigenvals + 1e-4), name='pca_final_feature')
 
   def _load_pca(self):
     self.pca_mean = numpy.load(


### PR DESCRIPTION
When I use the previous feature extraction program, I find that the CPU utilization rate is extremely high. The experimental machine has 56 cores and the cpu occupancy rate is 5600%. Most of them are occupied by the sys kernel, indicating that the cpu is doing a lot of memory swapping.
After debugging, I found that the problem lies in the pca operation, numpy can not use gpu acceleration so that the cpu occupancy rate is higher, and because the memory exchange between the gpu and cpu cause the cpu to do a lot of extra work, so I try to use tensorflow rewrite pca operation, found that the efficiency of feature extraction increased by 27%, cpu utilization from 5600% to 240%. 