### PR TITLE
Fix usage of extract_tfrecords_main.py

### DIFF
--- a/feature_extractor/README.md
+++ b/feature_extractor/README.md
@@ -39,7 +39,7 @@ to allow for multiple labels per video.
 
 Then, you can create the `tfrecord` by calling the binary:
 
-    python extract_tfrecords_main.py --input /path/to/vid_dataset.csv \
+    python extract_tfrecords_main.py --input_videos_csv /path/to/vid_dataset.csv \
         --output_tfrecords_file /path/to/output.tfrecord
 
 Now, you can use the output file for training and/or inference using our starter


### PR DESCRIPTION
The flag for the input CSV file was fixed in the example to be `--input_videos_csv`