### PR TITLE
Change directories used by evaluation script

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -204,7 +204,7 @@ def evaluation_loop(video_id_batch, prediction_batch, label_batch, loss,
       global_step_val = os.path.basename(latest_checkpoint).split("-")[-1]
 
       # Save model
-      saver.save(sess, os.path.join(FLAGS.train_dir, "inference_model"))
+      saver.save(sess, os.path.join(FLAGS.train_dir, "inference_model", "inference_model"))
     else:
       logging.info("No checkpoint file found.")
       return global_step_val

--- a/eval.py
+++ b/eval.py
@@ -323,7 +323,8 @@ def evaluate():
 
     saver = tf.train.Saver(tf.global_variables())
     summary_writer = tf.summary.FileWriter(
-        FLAGS.train_dir, graph=tf.get_default_graph())
+        os.path.join(FLAGS.train_dir, "eval"),
+        graph=tf.get_default_graph())
 
     evl_metrics = eval_util.EvaluationMetrics(reader.num_classes, FLAGS.top_k)
 

--- a/inference.py
+++ b/inference.py
@@ -123,7 +123,7 @@ def get_input_data_tensors(reader, data_pattern, batch_size, num_readers=1):
 def inference(reader, train_dir, data_pattern, out_file_location, batch_size, top_k):
   with tf.Session(config=tf.ConfigProto(allow_soft_placement=True)) as sess, gfile.Open(out_file_location, "w+") as out_file:
     video_id_batch, video_batch, num_frames_batch = get_input_data_tensors(reader, data_pattern, batch_size)
-    checkpoint_file = os.path.join(FLAGS.train_dir, "inference_model")
+    checkpoint_file = os.path.join(FLAGS.train_dir, "inference_model", "inference_model")
     if not gfile.Exists(checkpoint_file + ".meta"):
       raise IOError("Cannot find %s. Did you run eval.py?" % checkpoint_file)
     meta_graph_location = checkpoint_file + ".meta"


### PR DESCRIPTION
Hi

I tried to run training and evaluation processes simultaneously to train model and see it's progress. While training I met 2 problems:

1. Checkpoint file conflict
Training process writes `checkpoint` file to the training directory. Evaluation process exports inference model to the same directory and overwrites `checkpoint` file.
After training process crashed I wasn't able to restart it because `checkpoint` file contains references to inference model.
This PR exports inference model to `inference_model/` directory to avoid the file name conflict.

2. Training and evaluation summaries are written to the same directory and drawn in TensorBoard with same color. It is more informative to see the data drawn with orange and blue lines.
[Random example from the Internet](https://www.tensorflow.org/images/mnist_tensorboard.png)
This PR writes evaluation summaries to `eval/` directory