### PR TITLE
Enable CI on this Repo with new Github Actions function.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U tensorflow==1.14.0 six
+        pip install -U tensorflow==1.14 six
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,8 +19,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -U tensorflow==1.14 six
+        python -m pip install --upgrade tensorflow==1.14 six
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tensorflow==1.14.0 six
+        pip install tensorflow==1.14.0 six Pillow
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade tensorflow==1.14 six
+        python -m pip install --upgrade pip
+        python -m pip install tensorflow six
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6]
+        python-version: [3.6]
 
     steps:
     - uses: actions/checkout@v1
@@ -22,12 +22,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install tensorflow==1.14.0 six Pillow
     - name: Lint Check
-      with:
-        python-version: ${{ matrix.python-version }}
       run: |
         pip install yapf
         yapf --diff *.py
-      if: ${{ matrix.python-version }} == '3.6'
     - name: Test with nosetests
       run: |
         pip install -U nose

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tensorflow==1.14.0 six Pillow
+    - name: Lint Check
+      run: |
+        pip install yapf
+        yapf --diff *.py
+      if: ${{ matrix.python-version }} == '3.6'
     - name: Test with nosetests
       run: |
         pip install -U nose

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.5, 3.6]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.6]
 
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tensorflow==1.14.0 six
+        pip install -U tensorflow==1.14.0 six
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.6]
+        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tensorflow six
+        pip install tensorflow==1.14.0 six
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,6 +22,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install tensorflow==1.14.0 six Pillow
     - name: Lint Check
+      with:
+        python-version: ${{ matrix.python-version }}
       run: |
         pip install yapf
         yapf --diff *.py

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,27 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tensorflow=1.14.0 six
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tensorflow==1.14.0 six Pillow
-    - name: Test with pytest
+    - name: Test with nosetests
       run: |
-        pip install pytest
-        pytest
+        pip install -U nose
+        nosetests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,10 +21,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tensorflow==1.14.0 six Pillow
-    - name: Lint Check
+    - name: Yapf Check
       run: |
         pip install yapf
-        yapf --diff *.py
+        yapf --diff --style="{based_on_style: google, indent_width:2}" *.py
     - name: Test with nosetests
       run: |
         pip install -U nose

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tensorflow=1.14.0 six
+        pip install tensorflow==1.14.0 six
     - name: Test with pytest
       run: |
         pip install pytest


### PR DESCRIPTION
This PR tries to enable CI for this repo using Github's "Actions" function. 

It seems to work fine and supports multiple python 3 versions. 

Right now it is almost a no-op given we do not have any available successful test. But we can keep adding it in the future. 