### PR TITLE
Update the CI to trigger on PR from forks as well.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This test should still expect to fail. But will trigger twice, for both PR and push.

Previously, if user starts a PR from user forks, it will not trigger any test on PR.

That is being said, we should generally create PR from user forks. 