### PR TITLE
Allow OTF segment eval co-exist with video-level eval.

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -194,9 +194,10 @@ def evaluation_loop(fetches, saver, summary_writer, evl_metrics,
       global_step_val = os.path.basename(latest_checkpoint).split("-")[-1]
 
       # Save model
-      inference_model_name = "inference_model"
       if FLAGS.segment_labels:
         inference_model_name = "segment_inference_model"
+      else:
+        inference_model_name = "inference_model"
       saver.save(
           sess,
           os.path.join(FLAGS.train_dir, "inference_model",

--- a/eval.py
+++ b/eval.py
@@ -92,17 +92,17 @@ def get_input_evaluation_tensors(reader,
     if not files:
       raise IOError("Unable to find the evaluation files.")
     logging.info("number of evaluation files: %d", len(files))
-    filename_queue = tf.train.string_input_producer(files,
-                                                    shuffle=False,
-                                                    num_epochs=1)
+    filename_queue = tf.train.string_input_producer(
+        files, shuffle=False, num_epochs=1)
     eval_data = [
         reader.prepare_reader(filename_queue) for _ in range(num_readers)
     ]
-    return tf.train.batch_join(eval_data,
-                               batch_size=batch_size,
-                               capacity=3 * batch_size,
-                               allow_smaller_final_batch=True,
-                               enqueue_many=True)
+    return tf.train.batch_join(
+        eval_data,
+        batch_size=batch_size,
+        capacity=3 * batch_size,
+        allow_smaller_final_batch=True,
+        enqueue_many=True)
 
 
 def build_graph(reader,
@@ -125,10 +125,8 @@ def build_graph(reader,
   """
 
   global_step = tf.Variable(0, trainable=False, name="global_step")
-  input_data_dict = get_input_evaluation_tensors(reader,
-                                                 eval_data_pattern,
-                                                 batch_size=batch_size,
-                                                 num_readers=num_readers)
+  input_data_dict = get_input_evaluation_tensors(
+      reader, eval_data_pattern, batch_size=batch_size, num_readers=num_readers)
   video_id_batch = input_data_dict["video_ids"]
   model_input_raw = input_data_dict["video_matrix"]
   labels_batch = input_data_dict["labels"]
@@ -141,11 +139,12 @@ def build_graph(reader,
   model_input = tf.nn.l2_normalize(model_input_raw, feature_dim)
 
   with tf.variable_scope("tower"):
-    result = model.create_model(model_input,
-                                num_frames=num_frames,
-                                vocab_size=reader.num_classes,
-                                labels=labels_batch,
-                                is_training=False)
+    result = model.create_model(
+        model_input,
+        num_frames=num_frames,
+        vocab_size=reader.num_classes,
+        labels=labels_batch,
+        is_training=False)
     predictions = result["predictions"]
     tf.summary.histogram("model_activations", predictions)
     if "loss" in result.keys():
@@ -182,8 +181,9 @@ def evaluation_loop(fetches, saver, summary_writer, evl_metrics,
   """
 
   global_step_val = -1
-  with tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(
-      allow_growth=True))) as sess:
+  with tf.Session(
+      config=tf.ConfigProto(gpu_options=tf.GPUOptions(
+          allow_growth=True))) as sess:
     latest_checkpoint = tf.train.latest_checkpoint(FLAGS.train_dir)
     if latest_checkpoint:
       logging.info("Loading checkpoint for eval: %s", latest_checkpoint)
@@ -194,9 +194,10 @@ def evaluation_loop(fetches, saver, summary_writer, evl_metrics,
       global_step_val = os.path.basename(latest_checkpoint).split("-")[-1]
 
       # Save model
+      inference_model_name = "segment_inference_model" if FLAGS.segment_labels else "inference_model"
       saver.save(
           sess,
-          os.path.join(FLAGS.train_dir, "inference_model", "inference_model"))
+          os.path.join(FLAGS.train_dir, "inference_model", inference_model_name))
     else:
       logging.info("No checkpoint file found.")
       return global_step_val
@@ -239,10 +240,11 @@ def evaluation_loop(fetches, saver, summary_writer, evl_metrics,
                                                      output_data_dict["loss"])
         iteration_info_dict["examples_per_second"] = example_per_second
 
-        iterinfo = utils.AddGlobalStepSummary(summary_writer,
-                                              global_step_val,
-                                              iteration_info_dict,
-                                              summary_scope="Eval")
+        iterinfo = utils.AddGlobalStepSummary(
+            summary_writer,
+            global_step_val,
+            iteration_info_dict,
+            summary_scope="SegEval" if FLAGS.segment_labels else "Eval")
         logging.info("examples_processed: %d | %s", examples_processed,
                      iterinfo)
 
@@ -255,10 +257,11 @@ def evaluation_loop(fetches, saver, summary_writer, evl_metrics,
       epoch_info_dict["epoch_id"] = global_step_val
 
       summary_writer.add_summary(summary_val, global_step_val)
-      epochinfo = utils.AddEpochSummary(summary_writer,
-                                        global_step_val,
-                                        epoch_info_dict,
-                                        summary_scope="Eval")
+      epochinfo = utils.AddEpochSummary(
+          summary_writer,
+          global_step_val,
+          epoch_info_dict,
+          summary_scope="SegEval" if FLAGS.segment_labels else "Eval")
       logging.info(epochinfo)
       evl_metrics.clear()
     except Exception as e:  # pylint: disable=broad-except
@@ -294,8 +297,8 @@ def evaluate():
           feature_sizes=feature_sizes,
           segment_labels=FLAGS.segment_labels)
     else:
-      reader = readers.YT8MAggregatedFeatureReader(feature_names=feature_names,
-                                                   feature_sizes=feature_sizes)
+      reader = readers.YT8MAggregatedFeatureReader(
+          feature_names=feature_names, feature_sizes=feature_sizes)
 
     model = find_class_by_name(flags_dict["model"],
                                [frame_level_models, video_level_models])()
@@ -305,12 +308,13 @@ def evaluate():
       raise IOError("'eval_data_pattern' was not specified. Nothing to "
                     "evaluate.")
 
-    build_graph(reader=reader,
-                model=model,
-                eval_data_pattern=FLAGS.eval_data_pattern,
-                label_loss_fn=label_loss_fn,
-                num_readers=FLAGS.num_readers,
-                batch_size=FLAGS.batch_size)
+    build_graph(
+        reader=reader,
+        model=model,
+        eval_data_pattern=FLAGS.eval_data_pattern,
+        label_loss_fn=label_loss_fn,
+        num_readers=FLAGS.num_readers,
+        batch_size=FLAGS.batch_size)
     logging.info("built evaluation graph")
 
     # A dict of tensors to be run in Session.
@@ -325,9 +329,8 @@ def evaluate():
       fetches["label_weights"] = tf.get_collection("label_weights")[0]
 
     saver = tf.train.Saver(tf.global_variables())
-    summary_writer = tf.summary.FileWriter(os.path.join(FLAGS.train_dir,
-                                                        "eval"),
-                                           graph=tf.get_default_graph())
+    summary_writer = tf.summary.FileWriter(
+        os.path.join(FLAGS.train_dir, "eval"), graph=tf.get_default_graph())
 
     evl_metrics = eval_util.EvaluationMetrics(reader.num_classes, FLAGS.top_k,
                                               None)

--- a/eval.py
+++ b/eval.py
@@ -90,17 +90,17 @@ def get_input_evaluation_tensors(reader,
     if not files:
       raise IOError("Unable to find the evaluation files.")
     logging.info("number of evaluation files: %d", len(files))
-    filename_queue = tf.train.string_input_producer(
-        files, shuffle=False, num_epochs=1)
+    filename_queue = tf.train.string_input_producer(files,
+                                                    shuffle=False,
+                                                    num_epochs=1)
     eval_data = [
         reader.prepare_reader(filename_queue) for _ in range(num_readers)
     ]
-    return tf.train.batch_join(
-        eval_data,
-        batch_size=batch_size,
-        capacity=3 * batch_size,
-        allow_smaller_final_batch=True,
-        enqueue_many=True)
+    return tf.train.batch_join(eval_data,
+                               batch_size=batch_size,
+                               capacity=3 * batch_size,
+                               allow_smaller_final_batch=True,
+                               enqueue_many=True)
 
 
 def build_graph(reader,
@@ -123,8 +123,10 @@ def build_graph(reader,
   """
 
   global_step = tf.Variable(0, trainable=False, name="global_step")
-  input_data_dict = get_input_evaluation_tensors(
-      reader, eval_data_pattern, batch_size=batch_size, num_readers=num_readers)
+  input_data_dict = get_input_evaluation_tensors(reader,
+                                                 eval_data_pattern,
+                                                 batch_size=batch_size,
+                                                 num_readers=num_readers)
   video_id_batch = input_data_dict["video_ids"]
   model_input_raw = input_data_dict["video_matrix"]
   labels_batch = input_data_dict["labels"]
@@ -137,12 +139,11 @@ def build_graph(reader,
   model_input = tf.nn.l2_normalize(model_input_raw, feature_dim)
 
   with tf.compat.v1.variable_scope("tower"):
-    result = model.create_model(
-        model_input,
-        num_frames=num_frames,
-        vocab_size=reader.num_classes,
-        labels=labels_batch,
-        is_training=False)
+    result = model.create_model(model_input,
+                                num_frames=num_frames,
+                                vocab_size=reader.num_classes,
+                                labels=labels_batch,
+                                is_training=False)
 
     predictions = result["predictions"]
     tf.compat.v1.summary.histogram("model_activations", predictions)
@@ -181,9 +182,8 @@ def evaluation_loop(fetches, saver, summary_writer, evl_metrics,
   """
 
   global_step_val = -1
-  with tf.Session(
-      config=tf.ConfigProto(gpu_options=tf.GPUOptions(
-          allow_growth=True))) as sess:
+  with tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(
+      allow_growth=True))) as sess:
     latest_checkpoint = tf.train.latest_checkpoint(FLAGS.train_dir)
     if latest_checkpoint:
       logging.info("Loading checkpoint for eval: %s", latest_checkpoint)
@@ -300,8 +300,8 @@ def evaluate():
           feature_sizes=feature_sizes,
           segment_labels=FLAGS.segment_labels)
     else:
-      reader = readers.YT8MAggregatedFeatureReader(
-          feature_names=feature_names, feature_sizes=feature_sizes)
+      reader = readers.YT8MAggregatedFeatureReader(feature_names=feature_names,
+                                                   feature_sizes=feature_sizes)
 
     model = find_class_by_name(flags_dict["model"],
                                [frame_level_models, video_level_models])()
@@ -311,13 +311,12 @@ def evaluate():
       raise IOError("'eval_data_pattern' was not specified. Nothing to "
                     "evaluate.")
 
-    build_graph(
-        reader=reader,
-        model=model,
-        eval_data_pattern=FLAGS.eval_data_pattern,
-        label_loss_fn=label_loss_fn,
-        num_readers=FLAGS.num_readers,
-        batch_size=FLAGS.batch_size)
+    build_graph(reader=reader,
+                model=model,
+                eval_data_pattern=FLAGS.eval_data_pattern,
+                label_loss_fn=label_loss_fn,
+                num_readers=FLAGS.num_readers,
+                batch_size=FLAGS.batch_size)
     logging.info("built evaluation graph")
 
     # A dict of tensors to be run in Session.

--- a/inference.py
+++ b/inference.py
@@ -319,6 +319,9 @@ def inference(reader, train_dir, data_pattern, out_file_location, batch_size,
               float(preds[idx]) for idx in range(1, len(preds), 2)
           ]
           for cls, score in zip(pred_cls_ids, pred_cls_scores):
+            if not whitelisted_cls_mask[cls]:
+              # Skip non-whitelisted classes.
+              continue
             if cls not in heaps:
               heaps[cls] = []
             if len(heaps[cls]) >= FLAGS.segment_max_pred:

--- a/inference.py
+++ b/inference.py
@@ -129,18 +129,17 @@ def get_input_data_tensors(reader, data_pattern, batch_size, num_readers=1):
       raise IOError("Unable to find input files. data_pattern='" +
                     data_pattern + "'")
     logging.info("number of input files: " + str(len(files)))
-    filename_queue = tf.train.string_input_producer(
-        files, num_epochs=1, shuffle=False)
+    filename_queue = tf.train.string_input_producer(files,
+                                                    num_epochs=1,
+                                                    shuffle=False)
     examples_and_labels = [
         reader.prepare_reader(filename_queue) for _ in range(num_readers)
     ]
 
-    input_data_dict = (
-        tf.train.batch_join(
-            examples_and_labels,
-            batch_size=batch_size,
-            allow_smaller_final_batch=True,
-            enqueue_many=True))
+    input_data_dict = (tf.train.batch_join(examples_and_labels,
+                                           batch_size=batch_size,
+                                           allow_smaller_final_batch=True,
+                                           enqueue_many=True))
     video_id_batch = input_data_dict["video_ids"]
     video_batch = input_data_dict["video_matrix"]
     num_frames_batch = input_data_dict["num_frames"]
@@ -204,13 +203,12 @@ def inference(reader, train_dir, data_pattern, out_file_location, batch_size,
       with tarfile.open(FLAGS.output_model_tgz, "w:gz") as tar:
         for model_file in glob.glob(checkpoint_file + ".*"):
           tar.add(model_file, arcname=os.path.basename(model_file))
-        tar.add(
-            os.path.join(train_dir, "model_flags.json"),
-            arcname="model_flags.json")
+        tar.add(os.path.join(train_dir, "model_flags.json"),
+                arcname="model_flags.json")
       print("Tarred model onto " + FLAGS.output_model_tgz)
     with tf.device("/cpu:0"):
-      saver = tf.train.import_meta_graph(
-          meta_graph_location, clear_devices=True)
+      saver = tf.train.import_meta_graph(meta_graph_location,
+                                         clear_devices=True)
     logging.info("restoring variables from " + checkpoint_file)
     saver.restore(sess, checkpoint_file)
     input_tensor = tf.get_collection("input_batch_raw")[0]
@@ -365,11 +363,11 @@ def main(unused_argv):
       flags_dict["feature_names"], flags_dict["feature_sizes"])
 
   if flags_dict["frame_features"]:
-    reader = readers.YT8MFrameFeatureReader(
-        feature_names=feature_names, feature_sizes=feature_sizes)
+    reader = readers.YT8MFrameFeatureReader(feature_names=feature_names,
+                                            feature_sizes=feature_sizes)
   else:
-    reader = readers.YT8MAggregatedFeatureReader(
-        feature_names=feature_names, feature_sizes=feature_sizes)
+    reader = readers.YT8MAggregatedFeatureReader(feature_names=feature_names,
+                                                 feature_sizes=feature_sizes)
 
   if not FLAGS.output_file:
     raise ValueError("'output_file' was not specified. "

--- a/train.py
+++ b/train.py
@@ -530,13 +530,15 @@ class Trainer(object):
 
     last_checkpoint = saver.save(session, save_path, global_step_val)
 
-    model_dir = "{0}/export/step_{1}".format(self.train_dir, global_step_val)
-    logging.info("%s: Exporting the model at step %s to %s.",
-                 task_as_string(self.task), global_step_val, model_dir)
-
-    self.model_exporter.export_model(model_dir=model_dir,
-                                     global_step_val=global_step_val,
-                                     last_checkpoint=last_checkpoint)
+    # Temporarily disable the export. Given it might be the source which causes
+    # the cloud training performance issue.
+#     model_dir = "{0}/export/step_{1}".format(self.train_dir, global_step_val)
+#     logging.info("%s: Exporting the model at step %s to %s.",
+#                  task_as_string(self.task), global_step_val, model_dir)
+#
+#     self.model_exporter.export_model(model_dir=model_dir,
+#                                      global_step_val=global_step_val,
+#                                      last_checkpoint=last_checkpoint)
 
   def start_server_if_distributed(self):
     """Starts a server if the execution is distributed."""

--- a/train.py
+++ b/train.py
@@ -393,7 +393,6 @@ class Trainer(object):
     self.export_model_steps = export_model_steps
     self.last_model_export_step = 0
 
-
 #     if self.is_master and self.task.index > 0:
 #       raise StandardError("%s: Only one replica of master expected",
 #                           task_as_string(self.task))
@@ -532,6 +531,8 @@ class Trainer(object):
 
     # Temporarily disable the export. Given it might be the source which causes
     # the cloud training performance issue.
+
+
 #     model_dir = "{0}/export/step_{1}".format(self.train_dir, global_step_val)
 #     logging.info("%s: Exporting the model at step %s to %s.",
 #                  task_as_string(self.task), global_step_val, model_dir)

--- a/train.py
+++ b/train.py
@@ -393,6 +393,7 @@ class Trainer(object):
     self.export_model_steps = export_model_steps
     self.last_model_export_step = 0
 
+
 #     if self.is_master and self.task.index > 0:
 #       raise StandardError("%s: Only one replica of master expected",
 #                           task_as_string(self.task))
@@ -527,19 +528,7 @@ class Trainer(object):
     if global_step_val == self.last_model_export_step:
       return
 
-    last_checkpoint = saver.save(session, save_path, global_step_val)
-
-    # Temporarily disable the export. Given it might be the source which causes
-    # the cloud training performance issue.
-
-
-#     model_dir = "{0}/export/step_{1}".format(self.train_dir, global_step_val)
-#     logging.info("%s: Exporting the model at step %s to %s.",
-#                  task_as_string(self.task), global_step_val, model_dir)
-#
-#     self.model_exporter.export_model(model_dir=model_dir,
-#                                      global_step_val=global_step_val,
-#                                      last_checkpoint=last_checkpoint)
+    saver.save(session, save_path, global_step_val)
 
   def start_server_if_distributed(self):
     """Starts a server if the execution is distributed."""


### PR DESCRIPTION
- Allow OTF segment eval co-exist with video-level eval
- Improve the inference performance by whitelisting unnecessary classes.
- Improve training performance on Google Cloud by disabling the SavedModel export.